### PR TITLE
refactored all cobra commands to use a constructor pattern instead of init()

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -6,6 +6,7 @@ package configure
 import (
 	"fmt"
 	"maps"
+	"parm/internal/cmdutil"
 	"parm/internal/config"
 	"slices"
 
@@ -13,26 +14,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var ConfigCmd = &cobra.Command{
-	Use:     "config",
-	Aliases: []string{"configure, cfg"},
-	Short:   "Configures parm.",
-	Long:    `Prints the current configuration settings to your console.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		var settings map[string]any
-		if err := mapstructure.Decode(config.Cfg, &settings); err != nil {
-			return err
-		}
-		sorted := slices.Sorted(maps.Keys(settings))
-		for _, k := range sorted {
-			fmt.Printf("%s: %s\n", k, settings[k])
-		}
+func NewConfigureCmd(f *cmdutil.Factory) *cobra.Command {
+	var configCmd = &cobra.Command{
+		Use:     "config",
+		Aliases: []string{"configure, cfg"},
+		Short:   "Configures parm.",
+		Long:    `Prints the current configuration settings to your console.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var settings map[string]any
+			if err := mapstructure.Decode(config.Cfg, &settings); err != nil {
+				return err
+			}
+			sorted := slices.Sorted(maps.Keys(settings))
+			for _, k := range sorted {
+				fmt.Printf("%s: %s\n", k, settings[k])
+			}
 
-		return nil
-	},
-}
+			return nil
+		},
+	}
 
-func init() {
-	ConfigCmd.AddCommand(SetCmd)
-	ConfigCmd.AddCommand(ResetCmd)
+	configCmd.AddCommand(
+		NewSetCmd(f),
+		NewResetCmd(f),
+	)
+
+	return configCmd
 }

--- a/cmd/configure/reset.go
+++ b/cmd/configure/reset.go
@@ -6,6 +6,7 @@ package configure
 import (
 	"fmt"
 	"maps"
+	"parm/internal/cmdutil"
 	"parm/internal/config"
 	"slices"
 
@@ -14,52 +15,53 @@ import (
 	"github.com/spf13/viper"
 )
 
-var resetAll bool
+func NewResetCmd(f *cmdutil.Factory) *cobra.Command {
+	var resetAll bool
 
-// resetCmd represents the reset command
-var ResetCmd = &cobra.Command{
-	Use:   "reset <key>",
-	Short: "Resets key/value pairs to their default value.",
-	Long:  ``,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		var cfgMap map[string]any
-		if err := mapstructure.Decode(config.DefaultCfg, &cfgMap); err != nil {
-			return err
-		}
-
-		if resetAll {
-			args = slices.Sorted(maps.Keys(cfgMap))
-		} else {
-			slices.Sort(args)
-		}
-
-		for _, arg := range args {
-			def, ok := cfgMap[arg]
-			if !ok {
-				return fmt.Errorf("error: %s is not a valid configuration key", arg)
+	var resetCmd = &cobra.Command{
+		Use:   "reset <key>",
+		Short: "Resets key/value pairs to their default value.",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var cfgMap map[string]any
+			if err := mapstructure.Decode(config.DefaultCfg, &cfgMap); err != nil {
+				return err
 			}
 
-			viper.Set(arg, def)
-			fmt.Printf("Reset %s to default value: %v\n", arg, def)
-			if err := viper.WriteConfig(); err != nil {
-				return fmt.Errorf("error: failed to write config file: \n%w", err)
+			if resetAll {
+				args = slices.Sorted(maps.Keys(cfgMap))
+			} else {
+				slices.Sort(args)
 			}
-		}
-		return nil
-	},
-	Args: func(cmd *cobra.Command, args []string) error {
-		resetAllFlag, err := cmd.Flags().GetBool("all")
-		if err != nil {
-			return err
-		}
 
-		if resetAllFlag && len(args) > 0 {
-			return fmt.Errorf("error: no arguments accepted when using the --all flag.")
-		}
-		return nil
-	},
-}
+			for _, arg := range args {
+				def, ok := cfgMap[arg]
+				if !ok {
+					return fmt.Errorf("error: %s is not a valid configuration key", arg)
+				}
 
-func init() {
-	ResetCmd.Flags().BoolVarP(&resetAll, "all", "a", false, "Resets all config values to their defaults.")
+				viper.Set(arg, def)
+				fmt.Printf("Reset %s to default value: %v\n", arg, def)
+				if err := viper.WriteConfig(); err != nil {
+					return fmt.Errorf("error: failed to write config file: \n%w", err)
+				}
+			}
+			return nil
+		},
+		Args: func(cmd *cobra.Command, args []string) error {
+			resetAllFlag, err := cmd.Flags().GetBool("all")
+			if err != nil {
+				return err
+			}
+
+			if resetAllFlag && len(args) > 0 {
+				return fmt.Errorf("error: no arguments accepted when using the --all flag.")
+			}
+			return nil
+		},
+	}
+
+	resetCmd.Flags().BoolVarP(&resetAll, "all", "a", false, "Resets all config values to their defaults.")
+
+	return resetCmd
 }

--- a/cmd/configure/set.go
+++ b/cmd/configure/set.go
@@ -5,38 +5,41 @@ package configure
 
 import (
 	"fmt"
+	"parm/internal/cmdutil"
 	"parm/pkg/cmdparser"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-// setCmd represents the set command
-var SetCmd = &cobra.Command{
-	Use:   "set key=value",
-	Short: "Sets a key/value pair in the config",
-	Long:  ``,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		for _, val := range args {
-			k, v, err := cmdparser.StringToString(val)
-			if err != nil {
-				return err
-			}
-			viper.Set(k, v)
-			fmt.Printf("Set %s = %s\n", k, v)
-		}
-
-		if err := viper.WriteConfig(); err != nil {
-			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-				if err = viper.SafeWriteConfig(); err != nil {
-					return fmt.Errorf("error: failed to create config file: \n%w", err)
+func NewSetCmd(f *cmdutil.Factory) *cobra.Command {
+	// setCmd represents the set command
+	var setCmd = &cobra.Command{
+		Use:   "set key=value",
+		Short: "Sets a key/value pair in the config",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, val := range args {
+				k, v, err := cmdparser.StringToString(val)
+				if err != nil {
+					return err
 				}
-			} else {
-				return fmt.Errorf("error: failed to write config file: \n%w", err)
+				viper.Set(k, v)
+				fmt.Printf("Set %s = %s\n", k, v)
 			}
-		}
-		return nil
-	},
-}
 
-func init() {}
+			if err := viper.WriteConfig(); err != nil {
+				if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+					if err = viper.SafeWriteConfig(); err != nil {
+						return fmt.Errorf("error: failed to create config file: \n%w", err)
+					}
+				} else {
+					return fmt.Errorf("error: failed to write config file: \n%w", err)
+				}
+			}
+			return nil
+		},
+	}
+
+	return setCmd
+}

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -5,6 +5,7 @@ package info
 
 import (
 	"fmt"
+	"parm/internal/cmdutil"
 	"parm/internal/core/catalog"
 	"parm/internal/gh"
 	"parm/pkg/cmdparser"
@@ -17,42 +18,40 @@ import (
 // TODO: don't retrive package info from GitHub if it doesn't have any releases.
 // TODO: don't error out if trying to retrieve package info locally if the package doesn't exist.
 
-var getUpstream bool
+func NewInfoCmd(f *cmdutil.Factory) *cobra.Command {
+	var getUpstream bool
+	var infoCmd = &cobra.Command{
+		Use:   "info <owner>/<repo>",
+		Short: "Prints out information about a package",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			pkg := args[0]
+			token, err := gh.GetStoredApiKey(viper.GetViper())
+			if err != nil {
+				fmt.Printf("%s\ncontinuing without api key", err)
+			}
+			client := f.Provider(ctx, token).Repos()
+			var owner, repo string
 
-var NewProvider = gh.New
+			owner, repo, err = cmdparser.ParseRepoRef(pkg)
+			if err != nil {
+				owner, repo, err = cmdparser.ParseGithubUrlPattern(pkg)
+				if err != nil {
+					return err
+				}
+			}
 
-var InfoCmd = &cobra.Command{
-	Use:   "info <owner>/<repo>",
-	Short: "Prints out information about a package",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
-		pkg := args[0]
-		token, err := gh.GetStoredApiKey(viper.GetViper())
-		if err != nil {
-			fmt.Printf("%s\ncontinuing without api key", err)
-		}
-		client := NewProvider(ctx, token).Repos()
-		var owner, repo string
-
-		owner, repo, err = cmdparser.ParseRepoRef(pkg)
-		if err != nil {
-			owner, repo, err = cmdparser.ParseGithubUrlPattern(pkg)
+			info, err := catalog.GetPackageInfo(ctx, client, owner, repo, getUpstream)
 			if err != nil {
 				return err
 			}
-		}
+			pr := info.String()
+			fmt.Println(pr)
+			return nil
+		},
+	}
+	infoCmd.Flags().BoolVarP(&getUpstream, "get-upstream", "u", false, "Retrieves the Repository info from the GitHub repository instead of the locally installed package")
 
-		info, err := catalog.GetPackageInfo(ctx, client, owner, repo, getUpstream)
-		if err != nil {
-			return err
-		}
-		pr := info.String()
-		fmt.Println(pr)
-		return nil
-	},
-}
-
-func init() {
-	InfoCmd.Flags().BoolVarP(&getUpstream, "get-upstream", "u", false, "Retrieves the Repository info from the GitHub repository instead of the locally installed package")
+	return infoCmd
 }

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -5,26 +5,29 @@ package list
 
 import (
 	"fmt"
+	"parm/internal/cmdutil"
 	"parm/internal/core/catalog"
 
 	"github.com/spf13/cobra"
 )
 
-var ListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Lists out currently installed packages",
-	Args:  cobra.ExactArgs(0),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		list, data, err := catalog.GetInstalledPkgInfo()
-		if err != nil {
-			return err
-		}
-		for _, pkg := range list {
-			fmt.Println(pkg)
-		}
-		fmt.Printf("Total: %d packages installed.\n", data.NumPkgs)
-		return nil
-	},
-}
+func NewListCmd(f *cmdutil.Factory) *cobra.Command {
+	var listCmd = &cobra.Command{
+		Use:   "list",
+		Short: "Lists out currently installed packages",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			list, data, err := catalog.GetInstalledPkgInfo()
+			if err != nil {
+				return err
+			}
+			for _, pkg := range list {
+				fmt.Println(pkg)
+			}
+			fmt.Printf("Total: %d packages installed.\n", data.NumPkgs)
+			return nil
+		},
+	}
 
-func init() {}
+	return listCmd
+}

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -5,46 +5,49 @@ package remove
 
 import (
 	"fmt"
+	"parm/internal/cmdutil"
 	"parm/internal/core/uninstaller"
 	"parm/pkg/cmdparser"
 
 	"github.com/spf13/cobra"
 )
 
-// uninstallCmd represents the uninstall command
-var RemoveCmd = &cobra.Command{
-	Use:     "remove <owner>/<repo>...",
-	Aliases: []string{"uninstall", "rm"},
-	Short:   "Uninstalls a parm package",
-	Long:    `Uninstalls a parm package. Does not remove the configuration files`,
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := cmd.Context()
-		removed := make(map[string]bool)
+func NewRemoveCmd(f *cmdutil.Factory) *cobra.Command {
+	// uninstallCmd represents the uninstall command
+	var RemoveCmd = &cobra.Command{
+		Use:     "remove <owner>/<repo>...",
+		Aliases: []string{"uninstall", "rm"},
+		Short:   "Uninstalls a parm package",
+		Long:    `Uninstalls a parm package. Does not remove the configuration files`,
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			removed := make(map[string]bool)
 
-		for _, pkg := range args {
-			if _, ok := removed[pkg]; ok {
-				// already processed the package uninstallation
-				continue
-			}
-			removed[pkg] = true
-			owner, repo, err := cmdparser.ParseRepoRef(pkg)
+			for _, pkg := range args {
+				if _, ok := removed[pkg]; ok {
+					// already processed the package uninstallation
+					continue
+				}
+				removed[pkg] = true
+				owner, repo, err := cmdparser.ParseRepoRef(pkg)
 
-			if err != nil {
-				fmt.Printf("invalid package ref: %q: %s\n", pkg, err)
-				continue
-			}
+				if err != nil {
+					fmt.Printf("invalid package ref: %q: %s\n", pkg, err)
+					continue
+				}
 
-			err = uninstaller.RemoveSymlink(ctx, owner, repo)
-			if err != nil {
-				fmt.Printf("error: cannot remove symlink for %s/%s:\n%q", owner, repo, err)
-			}
+				err = uninstaller.RemoveSymlink(ctx, owner, repo)
+				if err != nil {
+					fmt.Printf("error: cannot remove symlink for %s/%s:\n%q", owner, repo, err)
+				}
 
-			err = uninstaller.Uninstall(ctx, owner, repo)
-			if err != nil {
-				fmt.Printf("error: cannot uninstall %s: %s\n", pkg, err)
+				err = uninstaller.Uninstall(ctx, owner, repo)
+				if err != nil {
+					fmt.Printf("error: cannot uninstall %s: %s\n", pkg, err)
+				}
 			}
-		}
-	},
+		},
+	}
+
+	return RemoveCmd
 }
-
-func init() {}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,46 +11,53 @@ import (
 	"parm/cmd/list"
 	"parm/cmd/remove"
 	"parm/cmd/update"
+	"parm/internal/cmdutil"
 	"parm/internal/config"
+	"parm/internal/gh"
 	"parm/parmver"
 
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "parm",
-	Short: "A zero-root, GitHub-native CLI package manager for installing and managing any GitHub-hosted tool.",
-	Long: `Parm is a thin CLI tool that downloads and installs prebuilt
+func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
+	// rootCmd represents the base command when called without any subcommands
+	var rootCmd = &cobra.Command{
+		Use:   "parm",
+		Short: "A zero-root, GitHub-native CLI package manager for installing and managing any GitHub-hosted tool.",
+		Long: `Parm is a thin CLI tool that downloads and installs prebuilt
 your programs. It has zero dependencies, zero root access, and is truly
 cross-platform on Windows, Linux, and MacOS.`,
-	Version: parmver.AppVersion.String(),
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		err := config.Init()
-		if err != nil {
-			return err
-		}
-		return nil
-	},
+		Version: parmver.AppVersion.String(),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			err := config.Init()
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	rootCmd.AddCommand(
+		configure.NewConfigureCmd(f),
+		install.NewInstallCmd(f),
+		remove.NewRemoveCmd(f),
+		update.NewUpdateCmd(f),
+		list.NewListCmd(f),
+		info.NewInfoCmd(f),
+		// search.NewSearchCmd(f),
+	)
+
+	return rootCmd
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
+	factory := &cmdutil.Factory{
+		Provider: gh.New,
+	}
+	err := NewRootCmd(factory).Execute()
 	if err != nil {
 		os.Exit(1)
 	}
-}
-
-func init() {
-	rootCmd.AddCommand(configure.ConfigCmd)
-	rootCmd.AddCommand(install.InstallCmd)
-	rootCmd.AddCommand(remove.RemoveCmd)
-	rootCmd.AddCommand(update.UpdateCmd)
-	rootCmd.AddCommand(list.ListCmd)
-	rootCmd.AddCommand(info.InfoCmd)
-
-	// INFO: To be implemented in v0.3.0
-	// rootCmd.AddCommand(search.SearchCmd)
 }

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -5,6 +5,7 @@ package search
 
 import (
 	"fmt"
+	"parm/internal/cmdutil"
 	"parm/internal/core/catalog"
 	"parm/internal/gh"
 
@@ -12,44 +13,44 @@ import (
 	"github.com/spf13/viper"
 )
 
-var query string
+func NewSearchCmd(f *cmdutil.Factory) *cobra.Command {
+	var query string
 
-var NewProvider = gh.New
+	// searchCmd represents the search command
+	var searchCmd = &cobra.Command{
+		Use:   "search",
+		Short: "Searches for repositories",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if query != "" && len(args) > 0 {
+				return fmt.Errorf("error: cannot have any args with the --query flag.")
+			} else {
+				exp := cobra.ExactArgs(1)
+				return exp(cmd, args)
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			token, err := gh.GetStoredApiKey(viper.GetViper())
+			if err != nil {
+				return err
+			}
+			client := f.Provider(ctx, token)
+			var opts = catalog.RepoSearchOptions{
+				Key:   nil,
+				Query: nil,
+			}
+			if query != "" {
+				opts.Query = &query
+			} else {
+				opts.Key = &args[0]
+			}
+			// TODO: finish this up
+			_, err = catalog.SearchRepo(ctx, client.Search(), opts)
+			return nil
+		},
+	}
 
-// searchCmd represents the search command
-var SearchCmd = &cobra.Command{
-	Use:   "search",
-	Short: "Searches for repositories",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if query != "" && len(args) > 0 {
-			return fmt.Errorf("error: cannot have any args with the --query flag.")
-		} else {
-			exp := cobra.ExactArgs(1)
-			return exp(cmd, args)
-		}
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
-		token, err := gh.GetStoredApiKey(viper.GetViper())
-		if err != nil {
-			return err
-		}
-		client := NewProvider(ctx, token)
-		var opts = catalog.RepoSearchOptions{
-			Key:   nil,
-			Query: nil,
-		}
-		if query != "" {
-			opts.Query = &query
-		} else {
-			opts.Key = &args[0]
-		}
-		// TODO: finish this up
-		_, err = catalog.SearchRepo(ctx, client.Search(), opts)
-		return nil
-	},
-}
+	searchCmd.Flags().StringVarP(&query, "query", "q", "", "Searches for the exact query string outlined by the GitHub REST API instead of a general search term.")
 
-func init() {
-	SearchCmd.Flags().StringVarP(&query, "query", "q", "", "Searches for the exact query string outlined by the GitHub REST API instead of a general search term.")
+	return searchCmd
 }

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -5,6 +5,7 @@ package update
 
 import (
 	"fmt"
+	"parm/internal/cmdutil"
 	"parm/internal/core/installer"
 	"parm/internal/core/updater"
 	"parm/internal/gh"
@@ -18,91 +19,91 @@ import (
 	"github.com/spf13/viper"
 )
 
-var strict bool
+func NewUpdateCmd(f *cmdutil.Factory) *cobra.Command {
+	var strict bool
 
-var NewProvider = gh.New
-
-// updateCmd represents the update command
-var UpdateCmd = &cobra.Command{
-	Use:   "update <owner>/<repo>",
-	Short: "Updates a package",
-	Long:  `Updates a package to the latest available version.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		for i, arg := range args {
-			owner, repo, err := cmdparser.ParseRepoRef(arg)
-			if err != nil {
-				owner, repo, err = cmdparser.ParseGithubUrlPattern(arg)
+	// updateCmd represents the update command
+	var updateCmd = &cobra.Command{
+		Use:   "update <owner>/<repo>",
+		Short: "Updates a package",
+		Long:  `Updates a package to the latest available version.`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			for i, arg := range args {
+				owner, repo, err := cmdparser.ParseRepoRef(arg)
 				if err != nil {
-					args = slices.Delete(args, i, i+1)
-					fmt.Printf("error: package %s not found, skipping...\n", arg)
-					continue
-				}
-				args[i] = fmt.Sprintf("%s/%s", owner, repo)
-			}
-		}
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
-		token, err := gh.GetStoredApiKey(viper.GetViper())
-		if err != nil {
-			fmt.Printf("%s\ncontinuing without api key.\n", err)
-		}
-		client := NewProvider(ctx, token).Repos()
-		inst := installer.New(client)
-		up := updater.New(client, inst)
-		updated := make(map[string]bool)
-		flags := updater.UpdateFlags{
-			Strict: strict,
-		}
-
-		for _, pkg := range args {
-			if _, ok := updated[pkg]; ok {
-				// already updated package
-				continue
-			}
-			updated[pkg] = true
-
-			// guaranteed to work now
-			owner, repo, _ := cmdparser.ParseRepoRef(pkg)
-
-			installPath := parmutil.GetInstallDir(owner, repo)
-			parentDir, _ := sysutil.GetParentDir(installPath)
-
-			res, err := up.Update(ctx, owner, repo, installPath, &flags, nil)
-			if err != nil {
-				_ = parmutil.Cleanup(parentDir)
-				fmt.Printf("error: failed to update %s/%s\n", owner, repo)
-				continue
-			}
-
-			// Write new manifest
-			old := res.OldManifest
-			man, err := manifest.New(owner, repo, res.Version, old.InstallType, res.InstallPath)
-			if err != nil {
-				return fmt.Errorf("error: failed to create manifest: \n%w", err)
-			}
-			err = man.Write(res.InstallPath)
-			if err != nil {
-				return err
-			}
-
-			// Symlinked executables to PATH
-			binPaths := man.GetFullExecPaths()
-			for _, execPath := range binPaths {
-				pathToSymLinkTo := parmutil.GetBinDir(man.Repo)
-
-				// TODO: use shims for windows instead?
-				err = sysutil.SymlinkBinToPath(execPath, pathToSymLinkTo)
-				if err != nil {
-					fmt.Println("error: could not symlink binary to PATH")
-					continue
+					owner, repo, err = cmdparser.ParseGithubUrlPattern(arg)
+					if err != nil {
+						args = slices.Delete(args, i, i+1)
+						fmt.Printf("error: package %s not found, skipping...\n", arg)
+						continue
+					}
+					args[i] = fmt.Sprintf("%s/%s", owner, repo)
 				}
 			}
-		}
-		return nil
-	},
-}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			token, err := gh.GetStoredApiKey(viper.GetViper())
+			if err != nil {
+				fmt.Printf("%s\ncontinuing without api key.\n", err)
+			}
+			client := f.Provider(ctx, token).Repos()
+			inst := installer.New(client)
+			up := updater.New(client, inst)
+			updated := make(map[string]bool)
+			flags := updater.UpdateFlags{
+				Strict: strict,
+			}
 
-func init() {
-	UpdateCmd.Flags().BoolVarP(&strict, "strict", "s", false, "Only available on pre-release channels. Will only install pre-release versions and not stable releases, even if there exists a stable version more up-to-date than a pre-release.")
+			for _, pkg := range args {
+				if _, ok := updated[pkg]; ok {
+					// already updated package
+					continue
+				}
+				updated[pkg] = true
+
+				// guaranteed to work now
+				owner, repo, _ := cmdparser.ParseRepoRef(pkg)
+
+				installPath := parmutil.GetInstallDir(owner, repo)
+				parentDir, _ := sysutil.GetParentDir(installPath)
+
+				res, err := up.Update(ctx, owner, repo, installPath, &flags, nil)
+				if err != nil {
+					_ = parmutil.Cleanup(parentDir)
+					fmt.Printf("error: failed to update %s/%s\n", owner, repo)
+					continue
+				}
+
+				// Write new manifest
+				old := res.OldManifest
+				man, err := manifest.New(owner, repo, res.Version, old.InstallType, res.InstallPath)
+				if err != nil {
+					return fmt.Errorf("error: failed to create manifest: \n%w", err)
+				}
+				err = man.Write(res.InstallPath)
+				if err != nil {
+					return err
+				}
+
+				// Symlinked executables to PATH
+				binPaths := man.GetFullExecPaths()
+				for _, execPath := range binPaths {
+					pathToSymLinkTo := parmutil.GetBinDir(man.Repo)
+
+					// TODO: use shims for windows instead?
+					err = sysutil.SymlinkBinToPath(execPath, pathToSymLinkTo)
+					if err != nil {
+						fmt.Println("error: could not symlink binary to PATH")
+						continue
+					}
+				}
+			}
+			return nil
+		},
+	}
+
+	updateCmd.Flags().BoolVarP(&strict, "strict", "s", false, "Only available on pre-release channels. Will only install pre-release versions and not stable releases, even if there exists a stable version more up-to-date than a pre-release.")
+
+	return updateCmd
 }

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -5,7 +5,7 @@ import (
 	"parm/internal/gh"
 )
 
-type ProviderFactory func(ctx context.Context, token string, opts ...gh.Option)
+type ProviderFactory func(ctx context.Context, token string, opts ...gh.Option) gh.Provider
 
 type Factory struct {
 	Provider ProviderFactory


### PR DESCRIPTION
Changes all cobra commands to be initiated via constructor funcs to make it easier to mock dependencies for integration and end2end testing.