### PR TITLE
fix: correct aliases formatting in config command

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -17,7 +17,7 @@ import (
 func NewConfigureCmd(f *cmdutil.Factory) *cobra.Command {
 	var configCmd = &cobra.Command{
 		Use:     "config",
-		Aliases: []string{"configure, cfg"},
+		Aliases: []string{"configure", "cfg"},
 		Short:   "Configures parm.",
 		Long:    `Prints the current configuration settings to your console.`,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- Fix aliases array formatting from single concatenated string to proper separate strings
- Changes `[]string{"configure, cfg"}` to `[]string{"configure", "cfg"}`

## Test plan
- Run `parm configure` and `parm cfg` to verify both aliases work correctly