### PR TITLE
fix: use lowercase appimage extension for case-insensitive matching

### DIFF
--- a/internal/core/installer/release.go
+++ b/internal/core/installer/release.go
@@ -129,7 +129,7 @@ func selectReleaseAsset(assets []*github.ReleaseAsset, goos, goarch string) ([]*
 		"arm":   {"armv7", "armv6", "armhf", "armv7l"},
 	}
 
-	extPref := []string{".tar.gz", ".tgz", ".tar.xz", ".zip", ".bin", ".AppImage"}
+	extPref := []string{".tar.gz", ".tgz", ".tar.xz", ".zip", ".bin", ".appimage"}
 	if goos == "windows" {
 		extPref = []string{".zip", ".exe", ".msi", ".bin"}
 	}


### PR DESCRIPTION
## Summary
- Fix extension preference list to use `.appimage` (lowercase) instead of `.AppImage`
- The asset name is already lowercased before matching, so the extension list should also use lowercase for consistency

## Test plan
- Install a tool that provides an AppImage release
- Verify the AppImage asset is correctly selected