### PR TITLE
[enhancement] Add VHS Tape Workflow

### DIFF
--- a/.github/workflows/vhs.yaml
+++ b/.github/workflows/vhs.yaml
@@ -1,19 +1,18 @@
 name: "VHS Tape"
 
 on:
+  workflow_call:
   workflow_dispatch:
     inputs:
       commit:
         description: Commit Image
         type: boolean
         default: true
-  release:
-    types: [published]
 
 env:
   tape: scripts/demo.tape
   image: assets/demo.gif
-  branch: images
+  branch: assets
 
 jobs:
   vhs:
@@ -28,32 +27,20 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v6
 
-      - name: "Release Wait"
-        if: ${{ github.event_name == 'release' }}
-        run: |
-          echo "Sleeping 5 minutes for release asset generation..."
-          sleep 300
-
       - name: "Install Release"
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ github.event_name == 'workflow_call' }}
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
           repo: ${{ github.repository }}
 
-      - name: "Debug Release"
-        if: ${{ github.event_name == 'release' }}
-        run: |
-          which parm
-          parm --version
-
       - name: "Setup Go"
-        if: ${{ github.event_name != 'release' }}
+        if: ${{ github.event_name != 'workflow_call' }}
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: "Go Build"
-        if: ${{ github.event_name != 'release' }}
+        if: ${{ github.event_name != 'workflow_call' }}
         run: |
           echo "Build and install to a reliable bin path."
           go build
@@ -61,7 +48,7 @@ jobs:
           mv parm "${{ runner.temp }}/bin"
           echo "${{ runner.temp }}/bin" >> "$GITHUB_PATH"
 
-      - name: "Debug"
+      - name: "Set Path"
         run: |
           echo "::group::PATH"
           echo "$PATH"
@@ -116,7 +103,7 @@ jobs:
           path: ${{ env.image }}
 
       - name: "Push Image"
-        if: ${{ github.event_name == 'release' || inputs.commit }}
+        if: ${{ github.event_name == 'workflow_call' || inputs.commit }}
         run: |
           git lfs install
           git config user.name "github-actions[bot]"
@@ -137,7 +124,7 @@ jobs:
           git push -f origin "${{ env.branch }}"
 
       - name: "Set URL"
-        if: ${{ github.event_name == 'release' || inputs.commit }}
+        if: ${{ github.event_name == 'workflow_call' || inputs.commit }}
         id: url
         run: |
           url="https://media.githubusercontent.com/media/${{ github.repository }}/refs/heads/${{ env.branch }}/${{ env.image }}"
@@ -145,7 +132,7 @@ jobs:
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: "Job Summary"
-        if: ${{ github.event_name == 'release' || inputs.commit }}
+        if: ${{ github.event_name == 'workflow_call' || inputs.commit }}
         continue-on-error: true
         run: |
           md="## VHS 📼\n\n"


### PR DESCRIPTION
Initial work for a VHS Tape Workflow for #32 

Was thinking this would be a good place to leverage git-lfs. The 2nd part of this workflow does the following:

- Checks out a branch (should be empty)
- Adds the image to the branch in git-lfs
- Pushes it to the git-lfs object for that branch
- Updates the image at the same url every time

```
https://media.githubusercontent.com/media/${{ github.repository }}/refs/heads/${{ env.branch }}/${{ env.image }}
```

GitHub ensured there is no possible way to run this workflow on a fork. SO I will have to fork the fork and disconnect the forked fork to even start testing (thanks M$)...

That being said, I do know we will at least need to inject our bin into the PATH, which I will get around too. Opening here now for visibility and feedback.

To make empty branch.

```shell
git clone https://github.com/smashedr/parm
cd parm
git checkout --orphan images
git commit --allow-empty -m images
git push origin images
```

TODO:

- [x] Add the `bin` to `PATH`
- [ ] Create empty `images` branch